### PR TITLE
Render a ViewComponent

### DIFF
--- a/lib/stimulus_reflex/reflex.rb
+++ b/lib/stimulus_reflex/reflex.rb
@@ -42,7 +42,7 @@ class StimulusReflex::Reflex
     end
   end
 
-  attr_reader :channel, :url, :element, :selectors, :method_name
+  attr_reader :channel, :url, :element, :selectors, :method_name, :component
 
   delegate :connection, to: :channel
   delegate :session, to: :request
@@ -100,6 +100,10 @@ class StimulusReflex::Reflex
   # IMPORTANT: The reflex will not re-render the page if the callback chain is halted
   def halted?
     !!@halted
+  end
+
+  def component?
+    !@component.nil?
   end
 
   def default_reflex


### PR DESCRIPTION
Some light refactoring to support rendering a ViewComponent specified by a reflex.

At the moment we rely on the Reflex setting the component instance variable but this could be tidied up into a module or reflex superclass.

We add a new method render_component which uses the controller’s view_context to render the component to a string.

I extracted the standard morph generation (for each selector scope, extract the partial html from the full html) into a collect_morphs method. Since the component is rendering a partial update already, we assign the component output to each selector.